### PR TITLE
Grant tsotack "@timsotack" publish permission to fortify-on-demand-uploader

### DIFF
--- a/permissions/plugin-fortify-on-demand-uploader.yml
+++ b/permissions/plugin-fortify-on-demand-uploader.yml
@@ -6,3 +6,4 @@ paths:
 developers:
 - "ryanblack"
 - "mtgibbs"
+- "tsotack"


### PR DESCRIPTION

# Description

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

https://github.com/jenkinsci/fortify-on-demand-uploader-plugin

Adding @timsotack to developers able to publish `fortify-on-demand-uploader-plugin`.

@mtgibbs (me) is the current maintainer.

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
